### PR TITLE
Add flake.nix for NixOS installations of snout-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Add libsnout to your flake.nix inputs:
 
 ```nix
   libsnout.url = "github:Darksecond/libsnout";
+
 ```
 
 Either use the package directly or add it to your overlays:
@@ -74,6 +75,7 @@ nixpkgs.overlay = [
 environment.systemPackages = with pkgs; [
   snout-cli
 ];
+
 ```
 ## Configuring 
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It's designed to be a library; easy to integrate in a variety of frontend projec
 
 - Building:
     - [Building and running the cli](#building-and-running-the-cli)
+    - [Installing on NixOS](#installing-on-nixos)
 - Configuring:
     - [Configuration file location](#configuration-file-location)
     - [Disabling specific tracking points](#disabling-specific-tracking-points)
@@ -53,6 +54,27 @@ Help on how to use the cli tool can be obtained with:
 snout-cli help
 ``` 
 
+### Installing on NixOS
+
+Add libsnout to your flake.nix inputs:
+
+```nix
+  libsnout.url = "github:Darksecond/libsnout";
+```
+
+Either use the package directly or add it to your overlays:
+
+```nix
+nixpkgs.overlay = [
+  (final: prev: {
+    snout-cli = libsnout.packages."${pkgs.stdenv.hostPlatform.system}".default;
+  })
+];
+
+environment.systemPackages = with pkgs; [
+  snout-cli
+];
+```
 ## Configuring 
 
 ### Configuration file location

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Rust library for face and eye tracking based on project babble";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+  let
+    inherit (nixpkgs) lib;
+    eachSystem = function: lib.genAttrs (
+      lib.platforms.linux ++ lib.platforms.darwin
+    ) (system:
+      function (import nixpkgs {
+        inherit system;
+      })
+    );
+  in
+  {
+    packages = eachSystem (pkgs: {
+      default = pkgs.rustPlatform.buildRustPackage {
+        pname = "snout-cli";
+        version = "main";
+
+        src = ./.;
+
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+        };
+        cargoBuildFlags = [ "--package" "snout-cli" ];
+
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          rustPlatform.bindgenHook
+          makeWrapper
+        ];
+
+        postFixup = let
+          libs = with pkgs; lib.makeLibraryPath [
+            llvm
+            onnxruntime
+            vulkan-loader
+          ];
+        in
+        ''
+          wrapProgram "$out/bin/snout-cli" \
+            --prefix LD_LIBRARY_PATH : "${libs}"
+        '';
+
+        meta = {
+          description = "A library for snout detection and tracking";
+          homepage = "https://github.com/Darksecond/libsnout";
+          platforms = lib.platforms.linux;
+          mainProgram = "snout-cli";
+        };
+      };
+    });
+  };
+}


### PR DESCRIPTION
Added a flake.nix that builds the snout-cli.
Updated README to include steps to install it on NixOS, however if @Helooprototo could scan over it to change it to be more inline with the rest of the readme, that would be nice